### PR TITLE
docs: agregar guia de MiniO

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,3 +105,21 @@
 - Interfaz frontend simple para mostrar catálogo de productos, detalles y estado de órdenes de corte.
 
 [Repositorio en GitHub](https://github.com/emadiaz15/InventoryManagementSystem-UI.git)
+## 📂 Integración con MiniO
+La interfaz hace uso de la API `InventoryManagementSystem-API` para almacenar y recuperar archivos en MiniO. Asegúrate de que el backend esté configurado y accesible.
+
+### Variables de entorno
+- `VITE_API_BASE_URL`: URL base de la API. Debe apuntar al despliegue de `InventoryManagementSystem-API`.
+
+### Endpoints relevantes
+- `POST /inventory/products/<productId>/files/` – subir archivos de un producto.
+- `GET /inventory/products/<productId>/files/<fileId>/download/` – descargar un archivo de producto.
+- `GET /inventory/products/<productId>/subproducts/<subproductId>/files/<fileId>/download/` – descargar un archivo de un subproducto.
+- `PUT /inventory/products/<productId>/subproducts/<subproductId>/files/<fileId>/` – actualizar un archivo de subproducto.
+- `DELETE /inventory/products/<productId>/files/<fileId>/delete/` – eliminar un archivo de producto.
+- `DELETE /inventory/products/<productId>/subproducts/<subproductId>/files/<fileId>/delete/` – eliminar un archivo de subproducto.
+
+### Habilitar subida y descarga
+1. Configura `InventoryManagementSystem-API` con acceso a MiniO y verifica que los endpoints anteriores estén disponibles.
+2. Establece `VITE_API_BASE_URL` en un archivo `.env` o como variable de entorno al ejecutar `npm run dev` o la imagen Docker.
+3. Inicia la UI; al subir o descargar archivos la aplicación enviará las solicitudes al backend, que se encargará de generar las URL presignadas de MiniO.


### PR DESCRIPTION
## Resumen
- se agregó una nueva sección en `README.md` detallando cómo la UI se comunica con la API para manejar archivos en MiniO
- se documentan las variables de entorno y los endpoints para subir y descargar

## Testing
- `npm run lint` *(falló: ESLint no encontró la configuración necesaria)*

------
https://chatgpt.com/codex/tasks/task_e_6861f4a7f404832b8094682cd9a5afb6