### PR TITLE
Fix category edit

### DIFF
--- a/src/features/category/components/CategoryEditModal.jsx
+++ b/src/features/category/components/CategoryEditModal.jsx
@@ -63,7 +63,7 @@ const CategoryEditModal = ({ category, isOpen, onClose, onSaveSuccess }) => {
     }
 
     try {
-      await onSaveSuccess(category.id, {
+      await onSaveSuccess({
         name: cleanName,
         description: cleanDescription,
       });


### PR DESCRIPTION
## Summary
- correct CategoryEditModal call to onSaveSuccess

## Testing
- `npm run lint` *(fails: ESLint couldn't find the config)*

------
https://chatgpt.com/codex/tasks/task_e_68620a71596c832bafa67bd26c63d417