### PR TITLE
Persist login tokens across browser sessions

### DIFF
--- a/src/api/clients.js
+++ b/src/api/clients.js
@@ -8,12 +8,12 @@ const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || "http://localhost:8000
 // ─────────────────────────────────────────────────────────────
 // 🧠 Helpers para tokens
 // ─────────────────────────────────────────────────────────────
-const getAccessToken = () => sessionStorage.getItem("accessToken");
-const getRefreshToken = () => sessionStorage.getItem("refreshToken");
+const getAccessToken = () => localStorage.getItem("accessToken");
+const getRefreshToken = () => localStorage.getItem("refreshToken");
 
 const clearTokens = () => {
-  sessionStorage.removeItem("accessToken");
-  sessionStorage.removeItem("refreshToken");
+  localStorage.removeItem("accessToken");
+  localStorage.removeItem("refreshToken");
   window.dispatchEvent(new Event("sessionExpired"));
 };
 

--- a/src/context/AuthProvider.jsx
+++ b/src/context/AuthProvider.jsx
@@ -67,8 +67,8 @@ export const AuthProvider = ({ children }) => {
                 user: userData,
             } = res.data;
 
-            sessionStorage.setItem("accessToken", access_token);
-            sessionStorage.setItem("refreshToken", refresh_token);
+            localStorage.setItem("accessToken", access_token);
+            localStorage.setItem("refreshToken", refresh_token);
 
             setUser(userData);
             setIsAuthenticated(true);

--- a/src/utils/sessionUtils.js
+++ b/src/utils/sessionUtils.js
@@ -3,15 +3,17 @@
  */
 
 // ─── Getters ─────────────────────────────────────────────────
-export const getAccessToken = () => sessionStorage.getItem("accessToken") || null;
-export const getRefreshToken = () => sessionStorage.getItem("refreshToken") || null;
+export const getAccessToken = () =>
+  localStorage.getItem("accessToken") || null;
+export const getRefreshToken = () =>
+  localStorage.getItem("refreshToken") || null;
 
 // ─── Limpiar sesión ─────────────────────────────────────────
 /**
- * Elimina todos los tokens del sessionStorage y emite un evento global.
+ * Elimina todos los tokens de localStorage y emite un evento global.
  */
 export const clearTokens = () => {
-  sessionStorage.removeItem("accessToken");
-  sessionStorage.removeItem("refreshToken");
+  localStorage.removeItem("accessToken");
+  localStorage.removeItem("refreshToken");
   window.dispatchEvent(new Event("sessionExpired"));
 };


### PR DESCRIPTION
## Summary
- store auth tokens in `localStorage` instead of `sessionStorage`
- update helpers and login flow to use the persistent storage

## Testing
- `npm run lint` *(fails: 450 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68620e7b2158832bb74121f45927d6fe