### PR TITLE
fix query devtools initialization

### DIFF
--- a/src/main.jsx
+++ b/src/main.jsx
@@ -11,6 +11,8 @@ import { QueryClientProvider } from '@tanstack/react-query';
 import { queryClient } from './lib/queryClient';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 
+const isDev = import.meta.env.MODE === 'development';
+
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
     <BrowserRouter>
@@ -20,7 +22,7 @@ ReactDOM.createRoot(document.getElementById('root')).render(
             <App />
           </DataPrefetchProvider>
         </AuthProvider>
-        <ReactQueryDevtools initialIsOpen={false} />
+        {isDev && <ReactQueryDevtools initialIsOpen={false} />}
       </QueryClientProvider>
     </BrowserRouter>
   </React.StrictMode>


### PR DESCRIPTION
## Summary
- avoid referencing ReactQueryDevtools in production builds

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6863072a5774832b845edb9299ed01b2