### PR TITLE
Fix auth initialization order

### DIFF
--- a/src/context/AuthProvider.jsx
+++ b/src/context/AuthProvider.jsx
@@ -28,6 +28,21 @@ export const AuthProvider = ({ children }) => {
         setProfileImage(url || null);
     };
 
+    const logout = useCallback(async () => {
+        try {
+            await logoutHelper();
+        } catch {
+            // noop
+        } finally {
+            clearTokens();
+            setUser(null);
+            setIsAuthenticated(false);
+            setProfileImage(null);
+            setError(null);
+            navigate("/login");
+        }
+    }, [navigate]);
+
     useEffect(() => {
         const validateToken = async () => {
             const accessToken = getAccessToken();
@@ -83,21 +98,6 @@ export const AuthProvider = ({ children }) => {
             setLoading(false);
         }
     };
-
-    const logout = useCallback(async () => {
-        try {
-            await logoutHelper();
-        } catch {
-            // noop
-        } finally {
-            clearTokens();
-            setUser(null);
-            setIsAuthenticated(false);
-            setProfileImage(null);
-            setError(null);
-            navigate("/login");
-        }
-    }, [navigate]);
 
     return (
         <AuthContext.Provider


### PR DESCRIPTION
## Summary
- adjust AuthProvider so logout is defined before useEffect

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68630eb439cc832bbe8a6b18dc14bdcd