### PR TITLE
Change token storage to sessionStorage

### DIFF
--- a/src/api/clients.js
+++ b/src/api/clients.js
@@ -8,12 +8,12 @@ const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || "http://localhost:8000
 // ─────────────────────────────────────────────────────────────
 // 🧠 Helpers para tokens
 // ─────────────────────────────────────────────────────────────
-const getAccessToken = () => localStorage.getItem("accessToken");
-const getRefreshToken = () => localStorage.getItem("refreshToken");
+const getAccessToken = () => sessionStorage.getItem("accessToken");
+const getRefreshToken = () => sessionStorage.getItem("refreshToken");
 
 const clearTokens = () => {
-  localStorage.removeItem("accessToken");
-  localStorage.removeItem("refreshToken");
+  sessionStorage.removeItem("accessToken");
+  sessionStorage.removeItem("refreshToken");
   window.dispatchEvent(new Event("sessionExpired"));
 };
 

--- a/src/context/AuthProvider.jsx
+++ b/src/context/AuthProvider.jsx
@@ -84,8 +84,8 @@ export const AuthProvider = ({ children }) => {
                 user: userData,
             } = res.data;
 
-            localStorage.setItem("accessToken", access_token);
-            localStorage.setItem("refreshToken", refresh_token);
+            sessionStorage.setItem("accessToken", access_token);
+            sessionStorage.setItem("refreshToken", refresh_token);
 
             setUser(userData);
             setIsAuthenticated(true);

--- a/src/utils/sessionUtils.js
+++ b/src/utils/sessionUtils.js
@@ -4,16 +4,16 @@
 
 // ─── Getters ─────────────────────────────────────────────────
 export const getAccessToken = () =>
-  localStorage.getItem("accessToken") || null;
+  sessionStorage.getItem("accessToken") || null;
 export const getRefreshToken = () =>
-  localStorage.getItem("refreshToken") || null;
+  sessionStorage.getItem("refreshToken") || null;
 
 // ─── Limpiar sesión ─────────────────────────────────────────
 /**
- * Elimina todos los tokens de localStorage y emite un evento global.
- */
+ * Elimina todos los tokens de sessionStorage y emite un evento global.
+*/
 export const clearTokens = () => {
-  localStorage.removeItem("accessToken");
-  localStorage.removeItem("refreshToken");
+  sessionStorage.removeItem("accessToken");
+  sessionStorage.removeItem("refreshToken");
   window.dispatchEvent(new Event("sessionExpired"));
 };


### PR DESCRIPTION
## Summary
- store tokens in `sessionStorage` instead of `localStorage`

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686477c0cbd8832bbfe3393ca9114f6b