### PR TITLE
Fix product table refresh after update

### DIFF
--- a/src/features/product/pages/ProductList.jsx
+++ b/src/features/product/pages/ProductList.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useCallback, useMemo } from "react";
+import { useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "react-router-dom";
 import Layout from "../../../pages/Layout";
 import Toolbar from "../../../components/common/Toolbar";
@@ -54,9 +55,14 @@ const ProductsList = () => {
   const handleCloseModal = () =>
     setModalState({ type: null, productData: null });
 
+  const queryClient = useQueryClient();
+
   const handleSaveProduct = () => {
     invalidate();
-    setPageUrl(null); // Vuelve a la primera página
+    queryClient.refetchQueries({ queryKey: ["products"] });
+    if (filters.code) {
+      setFilters((prev) => ({ ...prev, code: "" }));
+    }
     setSuccessMessage("¡Producto actualizado con éxito!");
     setShowSuccess(true);
     setTimeout(() => setShowSuccess(false), 3000);


### PR DESCRIPTION
## Summary
- refresh the product list after saving updates
- keep the current page when editing products
- clear active product code filter after an update

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run build`
- `serve -s dist -l 3000`


------
https://chatgpt.com/codex/tasks/task_e_6865c216172c832bad9639ff9e86ba55