### PR TITLE
Fix session expired modal logic

### DIFF
--- a/src/api/clients.js
+++ b/src/api/clients.js
@@ -21,7 +21,10 @@ const createApiClient = () => {
   instance.interceptors.response.use(
     (res) => res,
     (err) => {
-      if (err.response?.status === 401) clearTokens();
+      if (err.response?.status === 401) {
+        clearTokens();
+        window.dispatchEvent(new Event("sessionExpired"));
+      }
       return Promise.reject(err);
     }
   );

--- a/src/hooks/useSession.js
+++ b/src/hooks/useSession.js
@@ -14,9 +14,7 @@ export function useSession({ intervalMs = 30000 } = {}) {
       const accessToken = getAccessToken();
 
       if (!accessToken) {
-        console.warn("🚫 [Session] No hay accessToken, cerrando sesión");
-        clearTokens();
-        window.dispatchEvent(new Event("sessionExpired"));
+        console.warn("🚫 [Session] No hay accessToken, omitiendo chequeo");
         return;
       }
 

--- a/src/utils/sessionUtils.js
+++ b/src/utils/sessionUtils.js
@@ -10,10 +10,10 @@ export const getRefreshToken = () =>
 
 // ─── Limpiar sesión ─────────────────────────────────────────
 /**
- * Elimina todos los tokens de sessionStorage y emite un evento global.
-*/
+ * Elimina todos los tokens de sessionStorage.
+ * La emisión del evento de sesión expirada queda a cargo del llamador.
+ */
 export const clearTokens = () => {
   sessionStorage.removeItem("accessToken");
   sessionStorage.removeItem("refreshToken");
-  window.dispatchEvent(new Event("sessionExpired"));
 };


### PR DESCRIPTION
## Summary
- stop emitting sessionExpired event when clearing tokens
- ignore session check when no token found
- dispatch sessionExpired from axios interceptor on 401

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6865ea089d78832bbfe35cfd757e435d