### PR TITLE
Fix out-of-range index in ProductCarouselOverlay

### DIFF
--- a/src/features/product/components/ProductCarouselOverlay.jsx
+++ b/src/features/product/components/ProductCarouselOverlay.jsx
@@ -94,6 +94,12 @@ const ProductCarouselOverlay = ({
         return () => window.removeEventListener("keydown", handleKey);
     }, [current, localImages, isEmbedded, onClose, nextSlide, prevSlide]);
 
+    useEffect(() => {
+        if (current >= localImages.length && localImages.length > 0) {
+            setCurrent(localImages.length - 1);
+        }
+    }, [current, localImages.length]);
+
     const openInNewTab = (url) => window.open(url, "_blank");
 
     const handleDelete = () => {
@@ -119,8 +125,12 @@ const ProductCarouselOverlay = ({
         );
     }
 
-    const currentItem = localImages[current];
-    const mediaType = getMediaType(currentItem.contentType, currentItem.filename);
+    const safeIndex = Math.min(current, localImages.length - 1);
+    const currentItem = localImages[safeIndex];
+    const mediaType = getMediaType(
+        currentItem?.contentType,
+        currentItem?.filename
+    );
 
     return (
         <div className="w-full">


### PR DESCRIPTION
## Summary
- guard against invalid image index when items are removed
- keep current index within bounds to avoid runtime errors

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6865ec5bb094832baebecf9a55edf58d