### PR TITLE
Fix image carousel spinner persistence

### DIFF
--- a/src/features/product/components/ProductCarouselOverlay.jsx
+++ b/src/features/product/components/ProductCarouselOverlay.jsx
@@ -54,6 +54,7 @@ const ProductCarouselOverlay = ({
         }
 
         setLoading(true);
+        setImgLoaded(false);
         const preload = async () => {
             try {
                 const formatted = images.map((img) => {
@@ -77,7 +78,6 @@ const ProductCarouselOverlay = ({
                 setLocalImages([]);
             } finally {
                 setLoading(false);
-                setImgLoaded(false);
             }
         };
 


### PR DESCRIPTION
## Summary
- ensure `imgLoaded` resets before loading images to avoid false spinner state

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_6865f2460590832bb044a32934da7042