### PR TITLE
Update to use signed profile image URLs

### DIFF
--- a/src/context/AuthProvider.jsx
+++ b/src/context/AuthProvider.jsx
@@ -24,7 +24,7 @@ export const AuthProvider = ({ children }) => {
     const navigate = useNavigate();
 
     const loadProfileImage = async (userData) => {
-        const url = userData?.image_url;
+        const url = userData?.image_signed_url || userData?.image_url;
         setProfileImage(url || null);
     };
 

--- a/src/features/user/components/UserEditModal.jsx
+++ b/src/features/user/components/UserEditModal.jsx
@@ -46,7 +46,7 @@ const UserEditModal = ({
         image: null,
         is_staff: user.is_staff || false,
       });
-      setHasImage(!!user?.image_url);
+      setHasImage(!!(user?.image_signed_url || user?.image_url));
       setInternalError('');
       setValidationErrors({});
     }
@@ -82,6 +82,7 @@ const UserEditModal = ({
           }));
           user.image = deletedUser.image || '';
           user.image_url = deletedUser.image_url || null;
+          user.image_signed_url = deletedUser.image_signed_url || null;
 
           setSuccessMessage('Imagen de perfil eliminada correctamente.');
           setTimeout(() => {
@@ -138,6 +139,7 @@ const UserEditModal = ({
           const imageUpdateResult = await updateProfileImage(formData.image, user.image, user.id);
           user.image = imageUpdateResult.image;
           user.image_url = imageUpdateResult.image_url;
+          user.image_signed_url = imageUpdateResult.image_signed_url;
           setHasImage(true);
         } catch (imgErr) {
           console.warn('⚠️ Error al actualizar imagen:', imgErr);

--- a/src/features/user/components/UserModalView.jsx
+++ b/src/features/user/components/UserModalView.jsx
@@ -20,13 +20,14 @@ const UserViewModal = ({ user, isOpen, onClose }) => {
         let isMounted = true;
 
         const loadImage = async () => {
-            if (!user.image_url) {
+            const rawUrl = user.image_signed_url || user.image_url;
+            if (!rawUrl) {
                 setImageStatus('error');
                 return;
             }
 
             try {
-                const url = await downloadProfileImage(user.image_url);
+                const url = await downloadProfileImage(rawUrl);
                 if (isMounted && url) {
                     setImageUrl(url);
                     setImageStatus('loaded');

--- a/src/features/user/components/UserTable.jsx
+++ b/src/features/user/components/UserTable.jsx
@@ -21,9 +21,9 @@ const UserTable = ({
         users.map((user) => ({
             "Usuario": (
                 <div className="flex items-center space-x-3">
-                    {user.image_url ? (
+                    {user.image_signed_url || user.image_url ? (
                         <img
-                            src={user.image_url}
+                            src={user.image_signed_url || user.image_url}
                             alt={`Avatar de ${user.username}`}
                             className="w-8 h-8 rounded-full object-cover"
                         />


### PR DESCRIPTION
## Summary
- handle signed image URLs when loading user profiles
- support signed URLs in user table and modals

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6870428b4970832bb4838258a06abbfa