### PR TITLE
Update to fetch profile images as blobs

### DIFF
--- a/src/context/AuthProvider.jsx
+++ b/src/context/AuthProvider.jsx
@@ -11,6 +11,7 @@ import { useNavigate } from "react-router-dom";
 import { djangoApi } from "@/api/clients";
 import { logoutHelper } from "./authHelpers";
 import { getAccessToken, clearTokens } from "@/utils/sessionUtils";
+import { downloadProfileImage } from "@/features/user/services/downloadProfileImage";
 
 const AuthContext = createContext(null);
 
@@ -24,8 +25,18 @@ export const AuthProvider = ({ children }) => {
     const navigate = useNavigate();
 
     const loadProfileImage = async (userData) => {
-        const url = userData?.image_url;
-        setProfileImage(url || null);
+        const rawUrl = userData?.image_signed_url || userData?.image_url;
+        if (!rawUrl) {
+            setProfileImage(null);
+            return;
+        }
+        try {
+            const imgUrl = await downloadProfileImage(rawUrl);
+            setProfileImage(imgUrl || null);
+        } catch (err) {
+            console.warn('⚠️ No se pudo cargar la imagen de perfil:', err);
+            setProfileImage(null);
+        }
     };
 
     const logout = useCallback(async () => {

--- a/src/features/user/components/ProfileImage.jsx
+++ b/src/features/user/components/ProfileImage.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, memo } from 'react';
 import { UserIcon } from '@heroicons/react/20/solid';
+import { downloadProfileImage } from '../services/downloadProfileImage';
 
 /**
  * 📷 Componente para mostrar imagen de perfil o icono por defecto.
@@ -9,19 +10,48 @@ import { UserIcon } from '@heroicons/react/20/solid';
  */
 const ProfileImage = ({ image }) => {
   const [errored, setErrored] = useState(false);
+  const [imgSrc, setImgSrc] = useState(null);
 
   // Cuando cambie la URL, reiniciamos el estado de error
   useEffect(() => {
+    let isMounted = true;
     setErrored(false);
+
+    const load = async () => {
+      if (!image || typeof image !== 'string' || image.trim() === '') {
+        setImgSrc(null);
+        return;
+      }
+      try {
+        const url = await downloadProfileImage(image);
+        if (isMounted) setImgSrc(url);
+      } catch (err) {
+        console.warn('⚠️ Error cargando imagen de perfil:', err);
+        if (isMounted) setErrored(true);
+      }
+    };
+
+    load();
+
+    return () => {
+      isMounted = false;
+    };
   }, [image]);
 
-  const hasValidImage = typeof image === 'string' && image.trim() !== '' && !errored;
+  // Liberar objeto URL cuando cambie o se desmonte
+  useEffect(() => {
+    return () => {
+      if (imgSrc) URL.revokeObjectURL(imgSrc);
+    };
+  }, [imgSrc]);
+
+  const hasValidImage = typeof imgSrc === 'string' && imgSrc.trim() !== '' && !errored;
 
   return (
     <div className="flex items-center justify-center w-32 h-32 min-w-[8rem] min-h-[8rem] rounded-full border-2 border-background-100 shadow-sm sm:w-40 sm:h-40 sm:min-w-[10rem] sm:min-h-[10rem] mx-auto bg-white overflow-hidden">
       {hasValidImage ? (
         <img
-          src={image}
+          src={imgSrc}
           alt="Imagen de perfil del usuario"
           className="w-full h-full object-cover rounded-full"
           loading="lazy"

--- a/src/features/user/components/UserEditModal.jsx
+++ b/src/features/user/components/UserEditModal.jsx
@@ -46,7 +46,7 @@ const UserEditModal = ({
         image: null,
         is_staff: user.is_staff || false,
       });
-      setHasImage(!!user?.image_url);
+      setHasImage(!!(user?.image_signed_url || user?.image_url));
       setInternalError('');
       setValidationErrors({});
     }
@@ -82,6 +82,7 @@ const UserEditModal = ({
           }));
           user.image = deletedUser.image || '';
           user.image_url = deletedUser.image_url || null;
+          user.image_signed_url = deletedUser.image_signed_url || null;
 
           setSuccessMessage('Imagen de perfil eliminada correctamente.');
           setTimeout(() => {
@@ -138,6 +139,7 @@ const UserEditModal = ({
           const imageUpdateResult = await updateProfileImage(formData.image, user.image, user.id);
           user.image = imageUpdateResult.image;
           user.image_url = imageUpdateResult.image_url;
+          user.image_signed_url = imageUpdateResult.image_signed_url;
           setHasImage(true);
         } catch (imgErr) {
           console.warn('⚠️ Error al actualizar imagen:', imgErr);

--- a/src/features/user/components/UserModalView.jsx
+++ b/src/features/user/components/UserModalView.jsx
@@ -20,13 +20,14 @@ const UserViewModal = ({ user, isOpen, onClose }) => {
         let isMounted = true;
 
         const loadImage = async () => {
-            if (!user.image_url) {
+            const rawUrl = user.image_signed_url || user.image_url;
+            if (!rawUrl) {
                 setImageStatus('error');
                 return;
             }
 
             try {
-                const url = await downloadProfileImage(user.image_url);
+                const url = await downloadProfileImage(rawUrl);
                 if (isMounted && url) {
                     setImageUrl(url);
                     setImageStatus('loaded');

--- a/src/features/user/components/UserTable.jsx
+++ b/src/features/user/components/UserTable.jsx
@@ -21,9 +21,9 @@ const UserTable = ({
         users.map((user) => ({
             "Usuario": (
                 <div className="flex items-center space-x-3">
-                    {user.image_url ? (
+                    {user.image_signed_url || user.image_url ? (
                         <img
-                            src={user.image_url}
+                            src={user.image_signed_url || user.image_url}
                             alt={`Avatar de ${user.username}`}
                             className="w-8 h-8 rounded-full object-cover"
                         />

--- a/src/features/user/services/downloadProfileImage.js
+++ b/src/features/user/services/downloadProfileImage.js
@@ -10,8 +10,15 @@ export const downloadProfileImage = async (imageUrl) => {
     return null;
   }
 
-  // En este caso no se necesita petición, la URL ya viene lista desde el backend
-  return imageUrl;
+  try {
+    const response = await fetch(imageUrl);
+    if (!response.ok) throw new Error(`HTTP ${response.status}`);
+    const blob = await response.blob();
+    return URL.createObjectURL(blob);
+  } catch (err) {
+    console.error("❌ Error al descargar imagen de perfil:", err);
+    return imageUrl;
+  }
 };
 
 export default downloadProfileImage;


### PR DESCRIPTION
## Summary
- download profile images as blobs for reliability
- display images via blob URLs in ProfileImage component
- load profile image through download service in AuthProvider

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6870428b4970832bb4838258a06abbfa