### PR TITLE
Invalidate React Query cache after product file operations

### DIFF
--- a/src/features/product/components/EditProductModal.jsx
+++ b/src/features/product/components/EditProductModal.jsx
@@ -21,7 +21,6 @@ const EditProductModal = ({
     isOpen,
     onClose,
     onSave,            // ← callback para refrescar al padre
-    onDeleteSuccess,
     children,
 }) => {
     const [formData, setFormData] = useState({
@@ -203,8 +202,7 @@ const EditProductModal = ({
         const success = await deleteFile(product.id, fileToDelete.id);
         if (success) {
             setIsDeleteOpen(false);
-            onDeleteSuccess?.(); // refresca archivos
-            onSave?.();          // refresca lista productos
+            onSave?.(); // refresca lista productos
         }
     };
 
@@ -386,7 +384,6 @@ EditProductModal.propTypes = {
     isOpen: PropTypes.bool.isRequired,
     onClose: PropTypes.func.isRequired,
     onSave: PropTypes.func,
-    onDeleteSuccess: PropTypes.func,
     children: PropTypes.node,
 };
 

--- a/src/features/product/components/EditSubproductModal.jsx
+++ b/src/features/product/components/EditSubproductModal.jsx
@@ -30,7 +30,6 @@ const EditSubproductModal = ({
     isOpen,
     onClose,
     onSave,
-    onDeleteSuccess,
     subproduct,
     children,
 }) => {
@@ -181,7 +180,6 @@ const EditSubproductModal = ({
         );
         if (success) {
             setIsDeleteOpen(false);
-            onDeleteSuccess?.();
             onSave?.(subproduct);
         }
     };
@@ -388,7 +386,6 @@ EditSubproductModal.propTypes = {
     isOpen: PropTypes.bool.isRequired,
     onClose: PropTypes.func.isRequired,
     onSave: PropTypes.func.isRequired,
-    onDeleteSuccess: PropTypes.func,
     subproduct: PropTypes.shape({
         id: PropTypes.number.isRequired,
         parent: PropTypes.number.isRequired,

--- a/src/features/product/components/ProductModals.jsx
+++ b/src/features/product/components/ProductModals.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from "react";
+import React, { useState, useEffect } from "react";
 import CreateProductModal from "./CreateProductModal";
 import EditProductModal from "./EditProductModal";
 import ViewProductModal from "./ViewProductModal";
@@ -7,7 +7,7 @@ import DeleteMessage from "../../../components/common/DeleteMessage";
 import Spinner from "../../../components/ui/Spinner";
 import { useAuth } from "../../../context/AuthProvider";
 
-import { listProductFiles } from "@/features/product/services/products/files";
+import { useProductFileList } from "@/features/product/hooks/useProductFileHooks";
 import { enrichFilesWithBlobUrls } from "@/services/files/fileAccessService";
 
 /**
@@ -29,26 +29,36 @@ const ProductModals = ({
     const isStaff = user?.is_staff;
     const { type = "", productData = {}, showCarousel = false } = modalState || {};
     const productId = productData?.id;
-
-    const loadFiles = useCallback(async () => {
-        if (!productId || !["view", "edit"].includes(type)) return;
-
-        setLoadingFiles(true);
-        try {
-            const rawFiles = await listProductFiles(productId);
-            const enriched = await enrichFilesWithBlobUrls({ productId, rawFiles });
-            setFiles(enriched);
-        } catch (err) {
-            console.error("❌ No se pudieron cargar archivos del producto:", err);
-            setFiles([]);
-        } finally {
-            setLoadingFiles(false);
-        }
-    }, [productId, type]);
+    const { data: rawFiles = [], isLoading: loadingRaw } = useProductFileList(
+        productId && ["view", "edit"].includes(type) ? productId : null
+    );
 
     useEffect(() => {
-        loadFiles();
-    }, [loadFiles]);
+        if (!productId || !["view", "edit"].includes(type)) return;
+
+        let ignore = false;
+        const controller = new AbortController();
+        setLoadingFiles(true);
+
+        enrichFilesWithBlobUrls({ productId, rawFiles, signal: controller.signal })
+            .then((enriched) => {
+                if (!ignore) setFiles(enriched);
+            })
+            .catch((err) => {
+                console.error("❌ No se pudieron cargar archivos del producto:", err);
+                if (!ignore) setFiles([]);
+            })
+            .finally(() => {
+                if (!ignore) setLoadingFiles(false);
+            });
+
+        return () => {
+            ignore = true;
+            controller.abort();
+        };
+    }, [productId, type, rawFiles]);
+
+    const isLoadingFiles = loadingRaw || loadingFiles;
 
     if (!type) return null;
 
@@ -70,9 +80,8 @@ const ProductModals = ({
                     onClose={closeModal}
                     product={productData}
                     onSave={onUpdateProduct}
-                    onDeleteSuccess={loadFiles}
                 >
-                    {loadingFiles ? (
+                    {isLoadingFiles ? (
                         <div className="flex items-center justify-center h-full">
                             <Spinner size="8" color="text-primary-500" />
                         </div>
@@ -81,7 +90,6 @@ const ProductModals = ({
                             images={files}
                             productId={productId}
                             onClose={closeModal}
-                            onDeleteSuccess={loadFiles}
                             editable={true}
                             isEmbedded
                         />
@@ -95,7 +103,7 @@ const ProductModals = ({
 
             {type === "view" && productData && (
                 <ViewProductModal isOpen={true} onClose={closeModal} product={productData}>
-                    {loadingFiles ? (
+                    {isLoadingFiles ? (
                         <div className="flex items-center justify-center h-full">
                             <Spinner size="8" color="text-primary-500" />
                         </div>
@@ -104,7 +112,6 @@ const ProductModals = ({
                             images={files}
                             productId={productId}
                             onClose={closeModal}
-                            onDeleteSuccess={loadFiles}
                             editable={false}
                             isEmbedded
                         />

--- a/src/features/product/components/ViewProductModal.jsx
+++ b/src/features/product/components/ViewProductModal.jsx
@@ -2,28 +2,27 @@ import React, { useState, useEffect } from "react";
 import Modal from "../../../components/ui/Modal";
 import { listCategories } from "../../category/services/listCategory";
 import { listTypes } from "../../type/services/listType";
-import { listProductFiles } from "@/features/product/services/products/files";
-import { useEnrichedProductFiles } from "@/features/product/hooks/useProductFileHooks";
+import { useProductFileList, useEnrichedProductFiles } from "@/features/product/hooks/useProductFileHooks";
 import ProductCarouselOverlay from "../components/ProductCarouselOverlay";
 
 const ViewProductModal = ({ product, isOpen, onClose }) => {
     const [categories, setCategories] = useState([]);
     const [types, setTypes] = useState([]);
-    const [rawFiles, setRawFiles] = useState([]);
+    const { data: rawFiles = [], isLoading: loadingRaw } = useProductFileList(
+        isOpen ? product?.id : null
+    );
 
     useEffect(() => {
         if (!isOpen || !product?.id) return;
 
         const fetchData = async () => {
             try {
-                const [catResp, typeResp, fileResp] = await Promise.all([
+                const [catResp, typeResp] = await Promise.all([
                     listCategories("/inventory/categories/?limit=1000&status=true"),
                     listTypes("/inventory/types/?limit=1000&status=true"),
-                    listProductFiles(product.id),
                 ]);
                 setCategories(catResp.results || []);
                 setTypes(typeResp.results || []);
-                setRawFiles(fileResp || []);
             } catch (err) {
                 console.error("Error cargando datos del producto:", err);
             }
@@ -33,6 +32,7 @@ const ViewProductModal = ({ product, isOpen, onClose }) => {
     }, [isOpen, product?.id]);
 
     const { files, loading } = useEnrichedProductFiles(product?.id, rawFiles);
+    const isLoading = loading || loadingRaw;
 
     if (!product) return null;
 
@@ -76,7 +76,7 @@ const ViewProductModal = ({ product, isOpen, onClose }) => {
                 </div>
 
                 <div className="flex-1 bg-background-50 p-4 rounded overflow-y-auto max-h-[80vh]">
-                    {loading ? (
+                    {isLoading ? (
                         <div className="flex items-center justify-center h-full">
                             {/* si tienes un Spinner importado podrías usarlo aquí */}
                             Cargando archivos...


### PR DESCRIPTION
## Summary
- switch product and subproduct file listing hooks to React Query
- invalidate React Query cache when uploading or deleting product/subproduct files
- refresh product and subproduct modals using the new hooks
- remove now-unnecessary refresh callbacks

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68785179dfcc832b83e332317e011a88