### PR TITLE
Add category mutation hooks

### DIFF
--- a/src/features/category/hooks/useCategories.js
+++ b/src/features/category/hooks/useCategories.js
@@ -1,5 +1,5 @@
 // src/features/category/hooks/useCategories.js
-import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query"
+import { useQuery, useQueryClient } from "@tanstack/react-query"
 import { djangoApi } from "@/api/clients"
 import { buildQueryString } from "@/utils/queryUtils"
 
@@ -23,30 +23,6 @@ export const useCategories = (filters = {}) => {
     refetchOnWindowFocus: false,
   })
 
-  // MUTATIONS
-  const createCategory = useMutation({
-    mutationFn: (payload) =>
-      djangoApi.post("/inventory/categories/create/", payload),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["categories"] })
-    },
-  })
-
-  const updateCategory = useMutation({
-    mutationFn: ({ id, payload }) =>
-      djangoApi.put(`/inventory/categories/${id}/`, payload),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["categories"] })
-    },
-  })
-
-  const deleteCategory = useMutation({
-    mutationFn: (id) =>
-      djangoApi.delete(`/inventory/categories/${id}/`),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["categories"] })
-    },
-  })
 
   // PREFETCH de páginas
   const prefetchPage = (pageUrl) => {
@@ -66,12 +42,6 @@ export const useCategories = (filters = {}) => {
     loading,
     isError,
     error,
-    createCategory: createCategory.mutateAsync,
-    updateCategory: updateCategory.mutateAsync,
-    deleteCategory: deleteCategory.mutateAsync,
-    createStatus: createCategory.status,
-    updateStatus: updateCategory.status,
-    deleteStatus: deleteCategory.status,
     prefetchPage,
   }
 }

--- a/src/features/category/hooks/useCategoryMutations.js
+++ b/src/features/category/hooks/useCategoryMutations.js
@@ -1,0 +1,36 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  createCategory as createCategoryApi,
+  updateCategory as updateCategoryApi,
+  deleteCategory as deleteCategoryApi,
+} from "../services/categories";
+
+export const useCreateCategory = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: createCategoryApi,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["categories"] });
+    },
+  });
+};
+
+export const useUpdateCategory = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, payload }) => updateCategoryApi(id, payload),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["categories"] });
+    },
+  });
+};
+
+export const useDeleteCategory = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: deleteCategoryApi,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["categories"] });
+    },
+  });
+};

--- a/src/features/category/pages/CategoriesList.jsx
+++ b/src/features/category/pages/CategoriesList.jsx
@@ -10,6 +10,11 @@ import Spinner from "../../../components/ui/Spinner";
 import CategoryTable from "../components/CategoryTable";
 import CategoryModals from "../components/CategoryModals";
 import { useCategories } from "@/features/category/hooks/useCategories";
+import {
+  useCreateCategory,
+  useUpdateCategory,
+  useDeleteCategory,
+} from "@/features/category/hooks/useCategoryMutations";
 
 const CategoryList = () => {
   const navigate = useNavigate();
@@ -24,7 +29,7 @@ const CategoryList = () => {
   const [isProcessing, setIsProcessing] = useState(false);
   const [actionError, setActionError] = useState(null);
 
-  // 3️⃣ React Query hook para listado y mutaciones
+  // 3️⃣ React Query hook para listado
   const {
     categories,
     total,
@@ -33,11 +38,13 @@ const CategoryList = () => {
     loading,
     isError,
     error,
-    createCategory,
-    updateCategory,
-    deleteCategory,
     prefetchPage,
   } = useCategories(filters);
+
+  // 4️⃣ Mutaciones individuales
+  const createMut = useCreateCategory();
+  const updateMut = useUpdateCategory();
+  const deleteMut = useDeleteCategory();
 
   // 4️⃣ Columnas para el componente Filter
   const filterColumns = useMemo(
@@ -69,7 +76,7 @@ const CategoryList = () => {
     setIsProcessing(true);
     setActionError(null);
     try {
-      const res = await createCategory(data);
+      const res = await createMut.mutateAsync(data);
       handleActionSuccess(`Categoría "${res.name}" creada.`);
     } catch (err) {
       const msg = err.response?.data?.detail || err.message ||
@@ -85,7 +92,7 @@ const CategoryList = () => {
     setIsProcessing(true);
     setActionError(null);
     try {
-      const res = await updateCategory({ id, payload });
+      const res = await updateMut.mutateAsync({ id, payload });
       handleActionSuccess(`Categoría "${res.name}" actualizada.`);
     } catch (err) {
       const msg = err.response?.data?.detail || err.message ||
@@ -101,7 +108,7 @@ const CategoryList = () => {
     setIsProcessing(true);
     setActionError(null);
     try {
-      await deleteCategory(modalState.category.id);
+      await deleteMut.mutateAsync(modalState.category.id);
       handleActionSuccess(`Categoría "${modalState.category.name}" eliminada.`);
     } catch (err) {
       const msg = err.response?.data?.detail || err.message ||


### PR DESCRIPTION
## Summary
- add `useCategoryMutations` with create/update/delete hooks
- refactor `CategoriesList` to use the new mutation hooks
- keep `useCategories` focused on listing

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68817f2494b8832bb785f2374258927a