### PR TITLE
Refresh lists after mutations

### DIFF
--- a/src/features/category/hooks/useCategories.js
+++ b/src/features/category/hooks/useCategories.js
@@ -28,7 +28,7 @@ export const useCategories = (filters = {}) => {
     mutationFn: (payload) =>
       djangoApi.post("/inventory/categories/create/", payload),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["categories"] })
+      queryClient.invalidateQueries(["categories"])
     },
   })
 
@@ -36,7 +36,7 @@ export const useCategories = (filters = {}) => {
     mutationFn: ({ id, payload }) =>
       djangoApi.put(`/inventory/categories/${id}/`, payload),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["categories"] })
+      queryClient.invalidateQueries(["categories"])
     },
   })
 
@@ -44,7 +44,7 @@ export const useCategories = (filters = {}) => {
     mutationFn: (id) =>
       djangoApi.delete(`/inventory/categories/${id}/`),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["categories"] })
+      queryClient.invalidateQueries(["categories"])
     },
   })
 

--- a/src/features/product/hooks/useProductHooks.js
+++ b/src/features/product/hooks/useProductHooks.js
@@ -16,7 +16,7 @@ const BASE_URL = "/inventory/products/"
  * @param {string|null} pageUrl URL absoluta de next/previous page (opcional)
  */
 export const useProducts = (filters = {}, pageUrl = null) => {
-  const qc = useQueryClient()
+  const queryClient = useQueryClient()
 
   // URL de consulta o filtros
   const urlOrFilters = pageUrl || filters
@@ -43,22 +43,22 @@ export const useProducts = (filters = {}, pageUrl = null) => {
   // 🤝 Mutations v5
   const createMut = useMutation({
     mutationFn: createProduct,
-    onSuccess: () => qc.invalidateQueries(productKeys.all)
+    onSuccess: () => queryClient.invalidateQueries(["products"])
   })
 
   const updateMut = useMutation({
     mutationFn: ({ id, payload }) => updateProduct(id, payload),
-    onSuccess: () => qc.invalidateQueries(productKeys.all)
+    onSuccess: () => queryClient.invalidateQueries(["products"])
   })
 
   const deleteMut = useMutation({
     mutationFn: deleteProduct,
-    onSuccess: () => qc.invalidateQueries(productKeys.all)
+    onSuccess: () => queryClient.invalidateQueries(["products"])
   })
 
   // Prefetch de la siguiente/previa página (v5 prefetchQuery object signature)
   const prefetchPage = (nextUrl) => {
-    qc.prefetchQuery({
+    queryClient.prefetchQuery({
       queryKey: productKeys.list(filters, nextUrl),
       queryFn: () => listProducts(nextUrl)
     })

--- a/src/features/product/hooks/useSubproductHooks.js
+++ b/src/features/product/hooks/useSubproductHooks.js
@@ -31,10 +31,7 @@ export const useCreateSubproduct = (productId) => {
   return useMutation({
     mutationFn: (formData) => createSubproduct(productId, formData),
     onSuccess: () => {
-      queryClient.invalidateQueries({
-        predicate: (query) =>
-          query.queryKey[0] === "subproducts" && query.queryKey[1] === productId,
-      });
+      queryClient.invalidateQueries(["subproducts"])
     },
   });
 };
@@ -47,10 +44,7 @@ export const useUpdateSubproduct = (productId) => {
     mutationFn: ({ subproductId, formData }) =>
       updateSubproduct(productId, subproductId, formData),
     onSuccess: () => {
-      queryClient.invalidateQueries({
-        predicate: (query) =>
-          query.queryKey[0] === "subproducts" && query.queryKey[1] === productId,
-      });
+      queryClient.invalidateQueries(["subproducts"])
     },
   });
 };
@@ -62,10 +56,7 @@ export const useDeleteSubproduct = (productId) => {
   return useMutation({
     mutationFn: (subproductId) => deleteSubproduct(productId, subproductId),
     onSuccess: () => {
-      queryClient.invalidateQueries({
-        predicate: (query) =>
-          query.queryKey[0] === "subproducts" && query.queryKey[1] === productId,
-      });
+      queryClient.invalidateQueries(["subproducts"])
     },
   });
 };

--- a/src/features/type/hooks/useTypes.js
+++ b/src/features/type/hooks/useTypes.js
@@ -31,17 +31,17 @@ export const useTypes = (filters = {}) => {
   // 👉 Mutations
   const createMut = useMutation({
     mutationFn: createType,
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["types"] })
+    onSuccess: () => queryClient.invalidateQueries(["types"])
   })
 
   const updateMut = useMutation({
     mutationFn: ({ id, payload }) => updateType(id, payload),
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["types"] })
+    onSuccess: () => queryClient.invalidateQueries(["types"])
   })
 
   const deleteMut = useMutation({
     mutationFn: deleteType,
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["types"] })
+    onSuccess: () => queryClient.invalidateQueries(["types"])
   })
 
   // 👉 Prefetch de paginación (si lo necesitas)


### PR DESCRIPTION
## Summary
- trigger query invalidation by name for categories
- trigger query invalidation by name for types
- trigger query invalidation by name for products
- trigger query invalidation by name for subproducts
- rename local variable to queryClient

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68818a9d85c8832b9d3d78dfa94d9689