### PR TITLE
Implement loading overlay in Layout

### DIFF
--- a/src/features/category/pages/CategoriesList.jsx
+++ b/src/features/category/pages/CategoriesList.jsx
@@ -127,7 +127,7 @@ const CategoryList = () => {
 
   return (
     <>
-      <Layout>
+      <Layout isLoading={loading}>
         {showSuccess && (
           <div className="fixed top-20 right-5 z-50">
             <SuccessMessage

--- a/src/features/cuttingOrder/pages/CuttingOrderCart.jsx
+++ b/src/features/cuttingOrder/pages/CuttingOrderCart.jsx
@@ -102,7 +102,7 @@ const CuttingOrderCart = () => {
     }));
 
     return (
-        <Layout>
+        <Layout isLoading={submitting || loadingUsers}>
             <Toolbar
                 title="Carrito de Corte"
                 buttonText="Volver"

--- a/src/features/product/pages/ProductStockEvent.jsx
+++ b/src/features/product/pages/ProductStockEvent.jsx
@@ -142,7 +142,7 @@ const ProductStockEvent = () => {
     });
 
     return (
-        <Layout>
+        <Layout isLoading={loading}>
             <div className="flex-1 p-2 mt-14">
                 <Toolbar title="Historial de Stock" buttonText="Modificar Stock" />
                 <DateFilter onFilterChange={handleFilterChange} />

--- a/src/features/product/pages/SubproductList.jsx
+++ b/src/features/product/pages/SubproductList.jsx
@@ -131,7 +131,7 @@ const SubproductList = () => {
   };
 
   return (
-    <Layout>
+    <Layout isLoading={loading}>
       {showSuccess && (
         <div className="fixed top-20 right-5 z-[10000]">
           <SuccessMessage

--- a/src/features/product/pages/SubproductStockEvent.jsx
+++ b/src/features/product/pages/SubproductStockEvent.jsx
@@ -140,7 +140,7 @@ const SubproductStockEvent = () => {
     });
 
     return (
-        <Layout>
+        <Layout isLoading={loading}>
             <div className="flex-1 p-2 mt-14">
                 <Toolbar title="Historial de Stock del Subproducto" />
                 <DateFilter onFilterChange={handleFilterChange} />

--- a/src/features/type/pages/TypeList.jsx
+++ b/src/features/type/pages/TypeList.jsx
@@ -121,7 +121,7 @@ const TypeList = () => {
 
   return (
     <>
-      <Layout>
+      <Layout isLoading={loadingTypes || loadingCategories}>
         {/* Éxito */}
         {successMessage && (
           <div className="fixed top-20 right-5 z-50">

--- a/src/pages/Layout.jsx
+++ b/src/pages/Layout.jsx
@@ -3,8 +3,9 @@ import Navbar from "../components/common/Navbar";
 import Sidebar from "../components/common/Sidebar";
 import Footer from "../components/common/Footer";
 import { useAuth } from "../context/AuthProvider";
+import Spinner from "../components/ui/Spinner";
 
-const Layout = ({ children }) => {
+const Layout = ({ children, isLoading = false }) => {
     const [sidebarCollapsed, setSidebarCollapsed] = useState(true);
     const { profileImage } = useAuth();
 
@@ -13,7 +14,7 @@ const Layout = ({ children }) => {
     };
 
     return (
-        <div className="flex flex-col min-h-screen bg-background-100 text-text-primary">
+        <div className="flex flex-col min-h-screen bg-background-100 text-text-primary relative">
             <Navbar key={profileImage || 'default'} />
 
             <div className="flex flex-1 relative bg-background-100">
@@ -25,6 +26,12 @@ const Layout = ({ children }) => {
                 >
                     {children}
                 </div>
+
+                {isLoading && (
+                    <div className="absolute inset-0 bg-black bg-opacity-30 flex items-center justify-center z-50">
+                        <Spinner size="8" color="text-primary-500" />
+                    </div>
+                )}
             </div>
 
             <Footer />


### PR DESCRIPTION
## Summary
- add spinner overlay to Layout when `isLoading` is true
- wire `isLoading` prop in category list, cutting order cart, and product pages
- show overlay while loading types or categories on the types page

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68818ab95318832ba785bf800c0f7e66